### PR TITLE
Remove unused code and add a check for the camera object.

### DIFF
--- a/webcam_cv3.py
+++ b/webcam_cv3.py
@@ -3,6 +3,8 @@ import sys
 import logging as log
 import datetime as dt
 
+from time import sleep
+
 cascPath = sys.argv[1]
 faceCascade = cv2.CascadeClassifier(cascPath)
 log.basicConfig(filename='webcam.log',level=log.INFO)
@@ -11,6 +13,11 @@ video_capture = cv2.VideoCapture(0)
 anterior = 0
 
 while True:
+    if not video_capture.isOpened():
+        print('Unable to load camera.')
+        sleep(5)
+        pass
+
     # Capture frame-by-frame
     ret, frame = video_capture.read()
 
@@ -21,7 +28,6 @@ while True:
         scaleFactor=1.1,
         minNeighbors=5,
         minSize=(30, 30)
-        # flags=cv2.cv.CV_HAAR_SCALE_IMAGE
     )
 
     # Draw a rectangle around the faces
@@ -32,12 +38,8 @@ while True:
         anterior = len(faces)
         log.info("faces: "+str(len(faces))+" at "+str(dt.datetime.now()))
 
-    # Display the resulting frame
-    # cv2.imshow('Video', frame)
-
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break
 
 # When everything is done, release the capture
 video_capture.release()
-cv2.destroyAllWindows()


### PR DESCRIPTION
It is not necessary anymore to call `destroyAllWindows` given that no images are being showed anymore. Moreover, I added a `isOpened` check to the video_capture object, so that it tries again if the camera failed to be loaded.